### PR TITLE
[2024-11-01] Download

### DIFF
--- a/jcm-react/src/components/Main.jsx
+++ b/jcm-react/src/components/Main.jsx
@@ -1,5 +1,5 @@
 import '../css/Main.css';
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import MainPage from './mainPage/MainPage';
 import Chat from './mainPage/Chat';
 import MainInfo from './mainPage/MainInfo';
@@ -9,15 +9,27 @@ import MainDescribe from './mainPage/MainDescribe';
 import MainMethod from './mainPage/MainMethod';
 import MainEmail from './mainPage/MainEmail';
 
-import {SectionsContainer, Section} from 'react-fullpage';
+import { SectionsContainer, Section } from 'react-fullpage';
 import FooterPage from './common/FooterPage';
 
 const Main = () => {
-
     const [initialActiveSection, setInitialActiveSection] = useState(null);
+
     const onScroll = (p) => {
         if (initialActiveSection === null) setInitialActiveSection(p.activeSection);
     };
+
+    useEffect(() => {
+        const handleHashChange = () => {
+            window.history.replaceState(null, null, window.location.pathname);
+        };
+
+        window.addEventListener("hashchange", handleHashChange);
+
+        return () => {
+            window.removeEventListener("hashchange", handleHashChange);
+        };
+    }, []);
 
     let options = {
         scrollCallback: onScroll,


### PR DESCRIPTION
Main.jsx : 메인페이지에서 fullpage 기능을 사용할때 영역이동시 해당 영역의 해시가 주소창 ex) http://localhost:3000/#~~~ 에 #해시 로 붙는 문제 해결 해시가 나타나면 바로 지워지는 이벤트 추가 ( 아예 안보이게하는건 fullpage 라이브러리에서 지원하지 않기 때문에 불가능 )