### PR TITLE
[2024-11-21] Download / 어드민 페이지 -> Subscribe 페이지 총 가입 회원 / 일반 회원 / 구독…

### DIFF
--- a/jcm/src/main/java/com/jocomi/jcm/admin/controller/AdminController.java
+++ b/jcm/src/main/java/com/jocomi/jcm/admin/controller/AdminController.java
@@ -82,7 +82,18 @@ public class AdminController {
         List<Map<String, Object>> monthlyMembers = adminService.getMonthlyMembers();
         return ResponseEntity.ok(monthlyMembers);
     }
-
+    
+    // Subscribe 페이지 회원 정보 조회
+    @GetMapping("/subscribe-distribution")
+    public ResponseEntity<Map<String, Integer>> getSubscribeDistribution() {
+        try {
+            Map<String, Integer> distribution = adminService.getSubscribeDistribution();
+            return ResponseEntity.ok(distribution);
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(null);
+        }
+    }
 
     // 고객 수정
     @PutMapping("/customers/{memberId}")

--- a/jcm/src/main/java/com/jocomi/jcm/admin/model/mapper/AdminMapper.java
+++ b/jcm/src/main/java/com/jocomi/jcm/admin/model/mapper/AdminMapper.java
@@ -33,6 +33,10 @@ public interface AdminMapper {
     // 등급별 고객 데이터 반환
     Map<String, Object> calculateUserVIPDistribution();
 
+    // 월별 가입 고객 데이터 반환
 	List<Map<String, Object>> getMonthlyMembers();
+
+	// Subscribe 페이지 고객 데이터 반환
+	Map<String, Object> getSubscribeDistribution();
 
 }

--- a/jcm/src/main/java/com/jocomi/jcm/admin/service/AdminService.java
+++ b/jcm/src/main/java/com/jocomi/jcm/admin/service/AdminService.java
@@ -58,6 +58,19 @@ public class AdminService {
         return adminMapper.getMonthlyMembers();
     }
     
+    // Subscribe 페이지 회원 고객 데이터 반환
+    public Map<String, Integer> getSubscribeDistribution() {
+        Map<String, Object> rawData = adminMapper.getSubscribeDistribution(); // Map<String, Object>로 받음
+        Map<String, Integer> processedData = new HashMap<>();
+
+        // BigDecimal 데이터를 Integer로 변환
+        processedData.put("TOTAL_USERS", ((BigDecimal) rawData.get("TOTAL_USERS")).intValue());
+        processedData.put("GENERAL_USERS", ((BigDecimal) rawData.get("GENERAL_USERS")).intValue());
+        processedData.put("SUBSCRIBED_USERS", ((BigDecimal) rawData.get("SUBSCRIBED_USERS")).intValue());
+
+        return processedData; // Map<String, Integer>로 변환 후 반환
+    }
+    
     // 모든 회원 정보 조회
     public List<Member> getAllMembers() {
         return adminMapper.getAllMembers();

--- a/jcm/src/main/resources/mappers/admin/AdminMapper.xml
+++ b/jcm/src/main/resources/mappers/admin/AdminMapper.xml
@@ -43,9 +43,11 @@
 		SELECT
 		TO_CHAR(MEMBER_DATE, 'YYYY-MM') AS MONTH,
 		COUNT(*) AS MEMBER_COUNT
-		FROM MEMBER
+		FROM
+		MEMBER
 		WHERE STATUS IN ('Y', 'A')
-		GROUP BY TO_CHAR(MEMBER_DATE, 'YYYY-MM')
+		GROUP BY TO_CHAR(MEMBER_DATE,
+		'YYYY-MM')
 		ORDER BY MONTH
 	</select>
 
@@ -63,6 +65,29 @@
 		P_IMG
 		FROM MEMBER
 	</select>
+
+	<!-- Subscribe 페이지 회원 조회 -->
+	<select id="getSubscribeDistribution" resultType="map">
+		SELECT
+		COUNT(*) AS TOTAL_USERS,
+		COUNT(CASE
+		WHEN m.MEMBER_ID NOT IN (
+		SELECT MEMBER_ID
+		FROM PAYMENT
+		WHERE PAY_STATUS = 'Y'
+		) THEN 1
+		ELSE NULL
+		END) AS GENERAL_USERS,
+		COUNT(DISTINCT CASE
+		WHEN p.PAY_STATUS = 'Y' THEN m.MEMBER_ID
+		ELSE NULL
+		END) AS SUBSCRIBED_USERS
+		FROM MEMBER m
+		LEFT JOIN PAYMENT p
+		ON m.MEMBER_ID = p.MEMBER_ID
+		WHERE m.STATUS IN ('Y', 'A')
+	</select>
+
 
 	<!-- 특정 회원 정보 수정 -->
 	<update id="updateMemberInfo"


### PR DESCRIPTION
… 회원 구분지어 차트 표기 기능 구현

Subscribe 페이지 총가입회원 / 일반회원 / 구독회원 데이터 차트 기능 구현

MEMBER 테이블에 값이 있는 회원 -> 총회원
PAYMENT 테이블 -> PAY_STATUS 값이 'Y' 인 유저는 구독회원
MEMBER 테이블에 값이 있으나 PAYMENT 테이블의 값이 없거나 혹은 PAY_STAUTS 값이 'N'인 유저는 일반회원